### PR TITLE
Fix broken link (parent dir traversal)

### DIFF
--- a/content/english/hpc/pipelining/branchless.md
+++ b/content/english/hpc/pipelining/branchless.md
@@ -88,7 +88,7 @@ $$
 x = c \cdot a + (1 - c) \cdot b
 $$
 
-This way you can eliminate branching, but this comes at the cost of evaluating *both* branches and the `cmov` itself. Because evaluating the ">=" branch costs nothing, the performance is exactly equal to [the "always yes" case](branching/#branch-prediction) in the branchy version.
+This way you can eliminate branching, but this comes at the cost of evaluating *both* branches and the `cmov` itself. Because evaluating the ">=" branch costs nothing, the performance is exactly equal to [the "always yes" case](../branching/#branch-prediction) in the branchy version.
 
 ### When It Is Beneficial
 


### PR DESCRIPTION
In the section on "Branchless Programming" the link back to the previous section on branching does not first go up a directory, trying to navigate to `/hpc/pipelining/branchless/branching/#branch-prediction` instead of `/hpc/pipelining/branching/#branch-prediction`.

I fixed this by using the `..` operator to first go up a level, which fixes the issue. If there is a cleaner way to make the link, feel free to do so :)