### PR TITLE
Changed incorrect parameter "-mpopcount" to "-mpopcnt" in section 4.2.

### DIFF
--- a/content/english/hpc/architecture/functions.md
+++ b/content/english/hpc/architecture/functions.md
@@ -1,6 +1,7 @@
 ---
 title: Functions and Recursion
 weight: 3
+published: true
 ---
 
 To "call a function" in assembly, you need to [jump](../loops) to its beginning and then jump back. But then two important problems arise:
@@ -55,11 +56,11 @@ add rsp, 8
 
 ; "call func"
 push rip ; <- instruction pointer (although accessing it like that is probably illegal)
-jump func
+jmp func
 
 ; "ret"
 pop  rcx ; <- choose any unused register
-jump rcx
+jmp rcx
 ```
 
 The memory region between `rbp` and `rsp` is called a *stack frame*, and this is where local variables of functions are typically stored. It is pre-allocated at the start of the program, and if you push more data on the stack than its capacity (8MB by default on Linux), you encounter a *stack overflow* error. Because modern operating systems don't actually give you memory pages until you read or write to their address space, you can freely specify a very large stack size, which acts more like a limit on how much stack memory can be used, and not a fixed amount every program has to use.

--- a/content/english/hpc/architecture/layout.md
+++ b/content/english/hpc/architecture/layout.md
@@ -1,6 +1,7 @@
 ---
 title: Machine Code Layout
 weight: 10
+published: true
 ---
 
 Computer engineers like to mentally split the [pipeline of a CPU](/hpc/pipelining) into two parts: the *front-end*, where instructions are fetched from memory and decoded, and the *back-end*, where they are scheduled and finally executed. Typically, the performance is bottlenecked by the execution stage, and for this reason, most of our efforts in this book are going to be spent towards optimizing around the back-end.
@@ -126,7 +127,7 @@ normal:
     ret
 swap:
     xchg edi, esi
-    jump normal
+    jmp normal
 ```
 
 This technique is quite handy when handling exceptions cases in general, and in high-level code, you can give the compiler a [hint](/hpc/compilation/situational) that a certain branch is more likely than the other:

--- a/content/english/hpc/compilation/flags.md
+++ b/content/english/hpc/compilation/flags.md
@@ -1,6 +1,7 @@
 ---
 title: Flags and Targets
 weight: 2
+published: true
 ---
 
 The first step of getting high performance from the compiler is to ask for it, which is done with over a hundred different compiler options, attributes, and pragmas.
@@ -21,7 +22,7 @@ There are also many other optimization flags that are not included even in `-Ofa
 
 The next thing you may want to do is to tell the compiler more about the computer(s) this code is supposed to be run on: the smaller the set of platforms is, the better. By default, it will generate binaries that can run on any relatively new (>2000) x86 CPU. The simplest way to narrow it down is to pass `-march` flag to specify the exact microarchitecture: `-march=haswell`. If you are compiling on the same computer that will run the binary, you can use `-march=native` for auto-detection.
 
-The instruction sets are generally backward-compatible, so it is often enough to just use the name of the oldest microarchitecture you need to support. A more robust approach is to list specific features that the CPU is guaranteed to have: `-mavx2`, `-mpopcount`. When you just want to *tune* the program for a particular machine without using any instructions that may crash it on incompatible CPUs, you can use the `-mtune` flag (by default `-march=x` also implies `-mtune=x`).
+The instruction sets are generally backward-compatible, so it is often enough to just use the name of the oldest microarchitecture you need to support. A more robust approach is to list specific features that the CPU is guaranteed to have: `-mavx2`, `-mpopcnt`. When you just want to *tune* the program for a particular machine without using any instructions that may crash it on incompatible CPUs, you can use the `-mtune` flag (by default `-march=x` also implies `-mtune=x`).
 
 These options can also be specified for a compilation unit with pragmas instead of compilation flags:
 


### PR DESCRIPTION
Changed incorrect parameter "-mpopcount" to "-mpopcnt" in section 4.2.
Changed incorrect instruction "jump" to "jmp" in section 2.4 and 2.6.