### PR TITLE
Correction to speed of light

### DIFF
--- a/content/english/hpc/arithmetic/float.md
+++ b/content/english/hpc/arithmetic/float.md
@@ -90,7 +90,7 @@ $$
 E = m c^2
 $$
 
-In this particular one, $m$ is typically of the same order of magnitude as the mass of a proton ($1.67 \cdot 10^{-27}$ kg) and $c$ is the speed of light ($3 \cdot 10^9$ m/s).
+In this particular one, $m$ is typically of the same order of magnitude as the mass of a proton ($1.67 \cdot 10^{-27}$ kg) and $c$ is the speed of light ($3 \cdot 10^8$ m/s).
 
 ### Floating-Point Numbers
 


### PR DESCRIPTION
The speed of light is 3x10^8 m/s, not 3x10^9 m/s.