### PR TITLE
fix binary-search examples

### DIFF
--- a/content/russian/cs/interactive/binary-search.md
+++ b/content/russian/cs/interactive/binary-search.md
@@ -51,17 +51,19 @@ x = 42
 Однако, если массив отсортирован, найти число $x$ в массиве можно и быстрее: можно аналогичным способом найти *нижнюю грань* (англ. *lower bound*) — самое малое число, не меньшее $x$ — и проверить, оказалось ли оно равно $x$.
 
 ```cpp
-bool find(int x, int *a, int n) {
-    int l = 0, r = n + 1;
-    // отрезок поиска теперь полуинтервал: [l, r)
-    while (l + 1 < r) {
-        int m = (l + r) / 2;
-        if (a[m] >= x)
-            l = m;
-        else
-            r = m;
-    }
-    return (l < n && a[l] == x);
+bool find(int x, int const *a, int n) {
+  int l = 0, r = n;
+  // отрезок поиска теперь полуинтервал: [l, r)
+  while (l < r) {
+    int const m = (l + r) / 2;
+    if (a[m] < x)
+      l = m + 1;
+    else if (a[m] > x)
+      r = m;
+    else
+      return true;
+  }
+  return false;
 }
 ```
 

--- a/content/russian/cs/interactive/binary-search.md
+++ b/content/russian/cs/interactive/binary-search.md
@@ -68,7 +68,7 @@ bool find(int x, int *a, int n) {
 Для стандартных контейнеров STL такая функция реализована:
 
 ```cpp
-bool find(x, vector<int> a) {
+bool find(int x, vector<int> a) {
     auto it = lower_bound(a.begin(), a.end(), x);
     return (it != a.end() && *it == x);
 }


### PR DESCRIPTION
check it out with code

```c++
#include <iostream>

namespace {

bool find(int x, int const *a, int n) {
  int l = 0, r = n + 1;
  // отрезок поиска теперь полуинтервал: [l, r)
  while (l + 1 < r) {
    int m = (l + r) / 2;
    if (a[m] >= x)
      l = m;
    else
      r = m;
  }
  return (l < n && a[l] == x);
}

bool find_new(int x, int const *a, int n) {
  int l = 0, r = n;
  // отрезок поиска теперь полуинтервал: [l, r)
  while (l < r) {
    int const m = (l + r) / 2;
    if (a[m] < x)
      l = m + 1;
    else if (a[m] > x)
      r = m;
    else
      return true;
  }
  return false;
}
} // namespace

int main(int argc, char const *argv[]) {
  int const a[1] = {1};
  int const b[2] = {1, 2};
  int const c[3] = {1, 2, 3};
  int const d[4] = {1, 2, 3, 4};
  int const e[5] = {1, 2, 3, 4, 5};
  std::cout << find(1, a, 1) << ":" << find_new(1, a, 1) << std::endl;
  std::cout << find(2, b, 2) << ":" << find_new(2, b, 2) << std::endl;
  std::cout << find(2, c, 3) << ":" << find_new(2, c, 3) << std::endl;
  std::cout << find(3, d, 4) << ":" << find_new(3, d, 4) << std::endl;
  std::cout << find(4, e, 5) << ":" << find_new(4, e, 5) << std::endl;
  std::cout << find(0, a, 1) << ":" << find_new(0, a, 1) << std::endl;
  std::cout << find(3, b, 2) << ":" << find_new(3, b, 2) << std::endl;
  std::cout << find(5, c, 3) << ":" << find_new(5, c, 3) << std::endl;
  std::cout << find(8, d, 4) << ":" << find_new(8, d, 4) << std::endl;
  std::cout << find(12, e, 5) << ":" << find_new(12, e, 5) << std::endl;
  return 0;
}
```

output:

```
0:1
1:1
0:1
0:1
0:1
0:0
0:0
0:0
0:0
0:0
```