### PR TITLE
Fix typo: "is is" to "is"

### DIFF
--- a/content/english/hpc/compilation/stages.md
+++ b/content/english/hpc/compilation/stages.md
@@ -14,7 +14,7 @@ There are possibilities to improve program performance in each of these stages.
 
 ### Interprocedural Optimization
 
-We have the last [stage](../stages), linking, because it is is both easier and faster to compile programs on a file-by-file basis and then link those files together — this way you can do this in parallel and also cache intermediate results.
+We have the last [stage](../stages), linking, because it is both easier and faster to compile programs on a file-by-file basis and then link those files together — this way you can do this in parallel and also cache intermediate results.
 
 It also gives the ability to distribute code as *libraries*, which can be either *static* or *shared*:
 

--- a/content/english/hpc/profiling/instrumentation.md
+++ b/content/english/hpc/profiling/instrumentation.md
@@ -48,7 +48,7 @@ Instrumentation can also be used to collect other types of information that can 
 
 - for a hash function, we are interested in the average length of its input;
 - for a binary tree, we care about its size and height;
-- for a sorting algorithm, we we want to know how many comparisons it does.
+- for a sorting algorithm, we want to know how many comparisons it does.
 
 In a similar way, we can insert counters in the code that compute these algorithm-specific statistics.
 


### PR DESCRIPTION
First of all, thanks for a fascinating book!
I haven't finished reading yet but I am learning a lot already from your book.

This pull requests fixes a typo "is is" to "is".
