### PR TITLE
Clarify the fact that stack grows downwards to avoid confusion.

### DIFF
--- a/content/english/hpc/architecture/functions.md
+++ b/content/english/hpc/architecture/functions.md
@@ -59,11 +59,13 @@ push rip ; <- instruction pointer (although accessing it like that is probably i
 jmp func
 
 ; "ret"
-pop  rcx ; <- choose any unused register
+pop rcx ; <- choose any unused register
 jmp rcx
 ```
 
 The memory region between `rbp` and `rsp` is called a *stack frame*, and this is where local variables of functions are typically stored. It is pre-allocated at the start of the program, and if you push more data on the stack than its capacity (8MB by default on Linux), you encounter a *stack overflow* error. Because modern operating systems don't actually give you memory pages until you read or write to their address space, you can freely specify a very large stack size, which acts more like a limit on how much stack memory can be used, and not a fixed amount every program has to use.
+
+> **NOTE**: You may feel confused when seeing, for example, `sub` is used for `push` instead of `pop` and vice versa, but it's just a convention chosen for x86 architecture: The stack grows downwards.
 
 <!--
 


### PR DESCRIPTION
When looking into how `sub` was used for `push`, I find it confusing since I expected `add` instead. It turns out that it's because the stack grows downwards. I think it's good to include this information to avoid confusions for future readers.