### PR TITLE
Add missing base struct to inherited structs.

### DIFF
--- a/content/english/hpc/architecture/indirect.md
+++ b/content/english/hpc/architecture/indirect.md
@@ -79,11 +79,11 @@ struct Animal {
     virtual void speak() { printf("<abstract animal sound>\n");}
 };
 
-struct Dog {
+struct Dog : Animal {
     void speak() override { printf("Bark\n"); }
 };
 
-struct Cat {
+struct Cat : Animal {
     void speak() override { printf("Meow\n"); }
 };
 ```


### PR DESCRIPTION
It's just a small bug in the code. The `Dog` a `Cat` structs inherit from the `Animal` struct but they don't show it in the code.