### PR TITLE
Fix typo in segment-trees.md

### DIFF
--- a/content/english/hpc/data-structures/segment-trees.md
+++ b/content/english/hpc/data-structures/segment-trees.md
@@ -618,7 +618,7 @@ This makes the `sum` query extremely fast and easy to implement:
 int sum(int k) {
     int s = 0;
     for (int h = 0; h < H; h++)
-        s += t[offset(h) + (k >> (h * b))];
+        s += t[offset(h) + (k >> (h * B))];
     return s;
 }
 ```


### PR DESCRIPTION
B is the width constant of wide segment tree. It should be capitalized as previous declaration.