### PR TITLE
Fix a bug in reduction.md `sum_simd` function

### DIFF
--- a/content/english/hpc/simd/reduction.md
+++ b/content/english/hpc/simd/reduction.md
@@ -40,7 +40,8 @@ int sum_simd(v8si *a, int n) {
 
     // add the remainder of a
     for (int i = n / 8 * 8; i < n; i++)
-        res += a[i];
+        for(int j = 0; j < 8; j++)
+            res += a[i][j];
         
     return res;
 }


### PR DESCRIPTION
Since `a` is a vector of 8 ints, it cannot be added directly with `int res`. We need an extra loop to iterate through every element in `a`.